### PR TITLE
Added loading screen

### DIFF
--- a/leagueoflegends
+++ b/leagueoflegends
@@ -212,8 +212,8 @@ start_LoL() {
         done
     fi
 
-    # prelaunch helper
-    ( port_waiting_daemon ) &
+    # prelaunch helper (added the zenity loading screen here)
+    ( port_waiting_daemon ) | zenity --progress --pulsate --no-cancel --title="League of Legends" --text="Waiting for the League of Legends client to load..." --auto-close &
 
     msg "Starting..."
     WIN_CLIENT_EXE="$(winepath -w "$CLIENT_EXE" 2>/dev/null | \
@@ -270,6 +270,7 @@ main() {
             ;;
         kill)
             wineserver --kill
+	    pkill -9 -f \\'--title=League of Legends' #Here I kill the zenity dialog if we kill league before the client starts.
             ;;
         run)
             $@

--- a/leagueoflegends
+++ b/leagueoflegends
@@ -213,7 +213,7 @@ start_LoL() {
     fi
 
     # prelaunch helper (added the zenity loading screen here)
-    ( port_waiting_daemon ) | zenity --progress --pulsate --no-cancel --title="League of Legends" --text="Waiting for the League of Legends client to load..." --auto-close &
+    ( port_waiting_daemon ) | zenity --progress --pulsate --no-cancel --title="League of Legends" --text="Waiting for the League of Legends client to load..." --window-icon="/usr/share/icons/hicolor/256x256/apps/leagueoflegends.png" --auto-close &
 
     msg "Starting..."
     WIN_CLIENT_EXE="$(winepath -w "$CLIENT_EXE" 2>/dev/null | \


### PR DESCRIPTION
Added a loading screen with zenity. It ends when the background process finishes or the user kills all the lol processes so it doesnt get stuck.
![Screenshot_2021-03-23_20-44-03](https://user-images.githubusercontent.com/17589605/112209893-49cad500-8c1a-11eb-8881-6767b151d4b0.png)
