### PR TITLE
Only stop LeagueClientUx process from current user

### DIFF
--- a/leagueoflegends
+++ b/leagueoflegends
@@ -185,7 +185,7 @@ install_LoL() {
 port_waiting_daemon() {
     # Find PID
     process=LeagueClientUx.exe
-    uxpid=$(timeout 2m sh -c "until pidof $process; do sleep 1; done")
+    uxpid=$(timeout 2m sh -c "until pgrep -u $USER -f $process; do sleep 1; done")
     if [ -z "$uxpid" ]; then
         die "Could not find process ${process}"
     fi


### PR DESCRIPTION
Fixes issues when multiple users try to launch LoL at the same time, for example on a multi-seat setup.

I know this is a _pretty_ niche use case, but it would be nice if the launch helper transparently supported launching multiple league clients (one per user, at least)

Admittedly, I haven't tested this change with this repository, but my wife and I have been running League on a multiseat Archlinux computer for months with this patch applied in the same spot in the Lutris launch script, with no issues being able to launch both our clients simultaneously. Without the patch, `pidof` often finds the other user's LeagueClientUx, and therefore fails to pause the correct one, so it eventually crashes before it can finish loading.