### PR TITLE
Add tip for autosetting abi.vsyscall32=0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ parameters. The second one depends on GloriousEggroll's wine-ge-custom, and
 requires setting `abi.vsyscall32=0`, which may have a negative impact on the
 performance of other 32-bit wine applications.
 
-For auto setting `abi.vsyscall32=0`, you can create a file `/etc/sysctl.d/99-vsyscall32.conf` with `abi.vsyscall32=0` content.
-`# echo "abi.vsyscall32=0" >> /etc/sysctl.d/99-vsyscall32.conf`
+For more information about setting kernel parameters at run time and preserving
+changes between reboots, please checkout the documentation of your own
+distribution. Typically you may want to do something like `echo 'abi.vsyscall32
+= 0' >> /etc/sysctl.d/99-league.conf`.
 
 
 | Arch User Repository (AUR)                                                          | Debian/Ubuntu                                                   | Manual installation    |


### PR DESCRIPTION
Users may complain that setting `abi.vsyscall=0` every time is inconvenient.