### PR TITLE
Fix locale auto-completion for fish

### DIFF
--- a/completion.fish
+++ b/completion.fish
@@ -1,25 +1,25 @@
 # Completions for leagueoflegends
 
 set locales \
-    'de_DE	German' \
-    'el_GR	Greek' \
-    'en_AU	English (Australia)' \
-    'en_GB	English (UK)' \
-    'en_US	English (US)' \
-    'es_ES	Spanish (Spain)' \
-    'es_MX	Spanish (Latin America)' \
-    'fr_FR	French' \
-    'hu_HU	Hungarian' \
-    'it_IT	Italian' \
-    'ja_JP	Japanese' \
-    'ko_KR	Korean' \
-    'pl_PL	Polish' \
-    'pt_BR	Portuguese (Brazil)' \
-    'ro_RO	Romanian' \
-    'ru_RU	Russian' \
-    'tr_TR	Turkish' \
-    'zh_CN	Chinese' \
-    'zh_TW	Taiwanese'
+		'de_DE	German' \
+		'el_GR	Greek' \
+		'en_AU	English (Australia)' \
+		'en_GB	English (UK)' \
+		'en_US	English (US)' \
+		'es_ES	Spanish (Spain)' \
+		'es_MX	Spanish (Latin America)' \
+		'fr_FR	French' \
+		'hu_HU	Hungarian' \
+		'it_IT	Italian' \
+		'ja_JP	Japanese' \
+		'ko_KR	Korean' \
+		'pl_PL	Polish' \
+		'pt_BR	Portuguese (Brazil)' \
+		'ro_RO	Romanian' \
+		'ru_RU	Russian' \
+		'tr_TR	Turkish' \
+		'zh_CN	Chinese' \
+		'zh_TW	Taiwanese'
 
 set -l commands (leagueoflegends -h | sed '/Commands:/,$!d' | grep -v 'Commands:' | awk -F ' ' '{print $1}')
 set -l commands_w_desc (
@@ -39,7 +39,7 @@ complete -c leagueoflegends -f
 complete -c leagueoflegends -n "not __fish_seen_subcommand_from $commands" -s h -l help    -d "Show help message" -f
 complete -c leagueoflegends -n "not __fish_seen_subcommand_from $commands" -s v -l verbose -d "Enable verbose output" -f
 complete -c leagueoflegends -n "not __fish_seen_subcommand_from $commands" -l pbe          -d "Launch the PBE patchline" -f
-complete -c leagueoflegends -n "not __fish_seen_subcommand_from $commands" -l locale       -d "Set locale (if different from the region)" -a "$locales" -f -r
+complete -c leagueoflegends -n "not __fish_seen_subcommand_from $commands" -l locale       -d "Set locale (if different from the region)" -a '$locales' -f -r
 
 # Main subcommands
 complete -c leagueoflegends -n "not __fish_seen_subcommand_from $commands" -a '$single_cmds_w_desc' -f

--- a/completion.fish
+++ b/completion.fish
@@ -1,25 +1,25 @@
 # Completions for leagueoflegends
 
 set locales \
-		'de_DE	German' \
-		'el_GR	Greek' \
-		'en_AU	English (Australia)' \
-		'en_GB	English (UK)' \
-		'en_US	English (US)' \
-		'es_ES	Spanish (Spain)' \
-		'es_MX	Spanish (Latin America)' \
-		'fr_FR	French' \
-		'hu_HU	Hungarian' \
-		'it_IT	Italian' \
-		'ja_JP	Japanese' \
-		'ko_KR	Korean' \
-		'pl_PL	Polish' \
-		'pt_BR	Portuguese (Brazil)' \
-		'ro_RO	Romanian' \
-		'ru_RU	Russian' \
-		'tr_TR	Turkish' \
-		'zh_CN	Chinese' \
-		'zh_TW	Taiwanese'
+	'de_DE	German' \
+	'el_GR	Greek' \
+	'en_AU	English (Australia)' \
+	'en_GB	English (UK)' \
+	'en_US	English (US)' \
+	'es_ES	Spanish (Spain)' \
+	'es_MX	Spanish (Latin America)' \
+	'fr_FR	French' \
+	'hu_HU	Hungarian' \
+	'it_IT	Italian' \
+	'ja_JP	Japanese' \
+	'ko_KR	Korean' \
+	'pl_PL	Polish' \
+	'pt_BR	Portuguese (Brazil)' \
+	'ro_RO	Romanian' \
+	'ru_RU	Russian' \
+	'tr_TR	Turkish' \
+	'zh_CN	Chinese' \
+	'zh_TW	Taiwanese'
 
 set -l commands (leagueoflegends -h | sed '/Commands:/,$!d' | grep -v 'Commands:' | awk -F ' ' '{print $1}')
 set -l commands_w_desc (


### PR DESCRIPTION
While testing earlier today i got under a bug where the locale list were displaying in a completely scrambled manner
| master | this PR |
|--|--|
| ![image](https://user-images.githubusercontent.com/20617307/231790025-28ba1c96-6b6b-41da-9ae8-b332d98c0d45.png) | ![Screenshot_45](https://user-images.githubusercontent.com/20617307/231790323-63a6d602-76b7-4981-95d8-a6786b81fce3.png)|

After some trial and error i figured it out it's because there was some unescaped characters in the definition of `locales` variable.
