### PR TITLE
Modify .desktop to default to discrete GPU

### DIFF
--- a/leagueoflegends.desktop
+++ b/leagueoflegends.desktop
@@ -8,6 +8,7 @@ Terminal=false
 Actions=kill;winecfg;
 Categories=Game;Wine;
 StartupWMClass=leagueclientux.exe
+PrefersNonDefaultGPU=true
 
 [Desktop Action kill]
 Name=kill LoL Processes


### PR DESCRIPTION
Hi! Thanks a lot for creating and maintaining this :)

Spec: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

Steam uses the same: https://github.com/ValveSoftware/steam-for-linux/issues/634

Also, unrelated, trying to validate the file it seems that the Wine category is invalid:

```sh
$ desktop-file-validate leagueoflegends.desktop 
leagueoflegends.desktop: error: value "Game;Wine;" for key "Categories" in group "Desktop Entry" contains an unregistered value "Wine"; values extending the format should start with "X-"
```

I can remove the Wine category on this PR if you want to